### PR TITLE
Add error message if trQuantity is used with a missing plural rule

### DIFF
--- a/lib/inter.js
+++ b/lib/inter.js
@@ -12,7 +12,12 @@
         renderers: {},
 
         trQuantity: function (patternByQuantity, number) { // ...
-            return this.getPatternRenderer(patternByQuantity[this.pluralRule(number)]).call(this, Array.prototype.slice.call(arguments, 1));
+            var pattern = patternByQuantity[this.pluralRule(number)];
+            if (pattern) {
+                return this.getPatternRenderer(pattern).call(this, Array.prototype.slice.call(arguments, 1));
+            } else {
+                return "[! trQuantity: Missing plural rule for `" + this.pluralRule(number) + "` !]";
+            }
         },
 
         /**


### PR DESCRIPTION
At the moment, the error message displayed comes from makePatternRenderer. If we show a message earlier, it's quicker to understand the problem if you haven't seen it before, without needing to look at a stack trace.