### PR TITLE
Replace node-time with moment-timezone

### DIFF
--- a/lib/ZoneInfo.js
+++ b/lib/ZoneInfo.js
@@ -1,7 +1,7 @@
 /*global console*/
 var Path = require('path'),
     fs = require('fs'),
-    time = require('time'),
+    moment = require('moment-timezone'),
     difficultTimeZoneIdToEnglishDisplayName = {
         "Antarctica/DumontDUrville": "Dumont d'Urville",
         "America/St_Thomas": "St. Thomas",
@@ -11,8 +11,8 @@ var Path = require('path'),
         "America/St_Kitts": "St. Kitts"
     },
     nextYear = new Date().getFullYear() + 1,
-    nextJanuary1st = new time.Date(nextYear, 0, 1),
-    nextJuly1st = new time.Date(nextYear, 6, 1);
+    nextJanuary1st = new Date(nextYear, 0, 1),
+    nextJuly1st = new Date(nextYear, 6, 1);
 
 function ZoneInfo(zoneInfoPath) {
     var that = this;
@@ -31,25 +31,34 @@ function ZoneInfo(zoneInfoPath) {
         var territoryId = fields[0],
             timeZoneId = fields[2];
 
-        // Try instantiating a time.Date object with this time zone.
-        // If this throws an exception, node-time's set of time zones is somehow different
-        // from /usr/share/zoneinfo/zone.tab:
-        new time.Date(nextJanuary1st.getTime(), timeZoneId);
+        // Try instantiating a moment-date in the timezone. moment-timezone carries
+        // a stringified timezone-db which is instantiated as objects after they are
+        // used the first time. After having attempted to use a timezone, we can
+        // check if there's an instantiated version in it's internal object. We have
+        // to do this, as it will fallback to UTC for an unknown timezone, and just
+        // `console.log()` a warning.
+        moment().tz(timeZoneId);
+        var val = Object.values(moment.tz._zones).some(function (x) { return typeof x !== 'string' && x.name === timeZoneId ;});
+        if (!val) {
+            // If this throws an exception, moment-timezone's set of time zones is somehow different
+            // from /usr/share/zoneinfo/zone.tab:
+            throw new Error('Timezone ' + timeZoneId + ' not found in moment-timezone.');
+        }
 
         that.numTimeZonesByTerritoryId[territoryId] = (that.numTimeZonesByTerritoryId[territoryId] || 0) + 1;
         that.territoryIdByTimeZoneId[timeZoneId] = territoryId;
         that.timeZoneIds.push(timeZoneId);
 
-        time.tzset(timeZoneId);
-        var localtimeNextJanuary1st = time.localtime(nextJanuary1st.getTime() / 1000),
-            localtimeNextJuly1st = time.localtime(nextJuly1st.getTime() / 1000),
-            utcStandardOffsetSeconds;
-        if (localtimeNextJanuary1st.isDaylightSavings) {
-            utcStandardOffsetSeconds = localtimeNextJuly1st.gmtOffset;
+        var localtimeNextJanuary1st = moment.tz(nextJanuary1st.getTime(), timeZoneId),
+            localtimeNextJuly1st = moment.tz(nextJuly1st.getTime(), timeZoneId),
+            utcStandardOffsetMinutes;
+
+        if (localtimeNextJanuary1st.isDST()) {
+            utcStandardOffsetMinutes = localtimeNextJuly1st.utcOffset();
         } else {
-            utcStandardOffsetSeconds = localtimeNextJanuary1st.gmtOffset;
+            utcStandardOffsetMinutes = localtimeNextJanuary1st.utcOffset();
         }
-        that.utcStandardOffsetSecondsByTimeZoneId[timeZoneId] = utcStandardOffsetSeconds;
+        that.utcStandardOffsetSecondsByTimeZoneId[timeZoneId] = utcStandardOffsetMinutes * 60;
     });
 }
 

--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "dependencies": {
     "async": "0.9.0",
     "cldr": "3.5.0",
+    "moment-timezone": "^0.5.31",
     "passerror": "1.1.0",
     "seq": "=0.3.5",
-    "time": "0.12.0",
     "uglify-js": "1.3.3",
     "uglifyast": "0.2.1",
     "underscore": "1.8.3",


### PR DESCRIPTION
I dumped the stringified JSON representation of `zoneInfo.utcStandardOffsetSecondsByTimeZoneId` into a file with the old
implementation, and again with the new based on moment-timezone.

There is no diff between the two JSON files. Below is the example code used to generate them:

```js
const ZoneInfo = require("./lib/ZoneInfo");
const ZoneInfoMoment = require("./lib/ZoneInfo-moment");

const zoneInfo = new ZoneInfo("/usr/share/zoneinfo");
const zoneInfoMoment = new ZoneInfoMoment("/usr/share/zoneinfo");

const fs = require('fs')

fs.writeFileSync('zoneInfoTime.json', JSON.stringify(zoneInfo.utcStandardOffsetSecondsByTimeZoneId, null, 2));
fs.writeFileSync('zoneInfoMoment.json', JSON.stringify(zoneInfoMoment.utcStandardOffsetSecondsByTimeZoneId, null, 2));
```

There was no specific tests of this module, but the build still works. 

I wanted to use https://github.com/prantlf/timezone-support instead of moment-timezone, but due to  https://github.com/prantlf/timezone-support/issues/33 and the fact that they do not have a way for us to tell if a date is DST, I had to go with moment.