### PR TITLE
updated the moment-timezone module to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "async": "0.9.0",
     "cldr": "3.5.0",
-    "moment-timezone": "^0.5.31",
+    "moment-timezone": "^0.5.34",
     "passerror": "1.1.0",
     "seq": "=0.3.5",
     "uglify-js": "1.3.3",


### PR DESCRIPTION
Timezone Pacific/Enderbury has been renamed to Pacific/Kanton hence the moment-timezone needs to be updated for the same.