### PR TITLE
A new Zone America/Ciudad_Juarez splits from America/Ojinaga hence the moment-timezone needs to be updated for the same.

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "async": "0.9.0",
     "cldr": "3.5.0",
-    "moment-timezone": "^0.5.34",
+    "moment-timezone": "^0.5.40",
     "passerror": "1.1.0",
     "seq": "=0.3.5",
     "uglify-js": "1.3.3",


### PR DESCRIPTION
A new Zone America/Ciudad_Juarez splits from America/Ojinaga hence the moment-timezone needs to be updated for the same from 0.5.34 to 0.5.40